### PR TITLE
Add filter method

### DIFF
--- a/src/SharpJuice.Essentials.Tests/MaybeFilterTests.cs
+++ b/src/SharpJuice.Essentials.Tests/MaybeFilterTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace SharpJuice.Essentials.Tests
+{
+    public class MaybeFilterTests
+    {
+        [Fact]
+        public void WhenNone_PredicateNotInvoked()
+        {
+            var maybe = default(Maybe<object>);
+            int calls = 0;
+            Predicate<object> predicate = _ =>
+            {
+                calls++;
+                return true;
+            };
+
+            var result = maybe.Filter(predicate);
+
+            result.Should().BeEmpty();
+            calls.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("Test")]
+        [InlineData(10)]
+        [InlineData(typeof(object))]
+        public void WhenSome_PredicateTrue_ReturnsSome<T>(T value)
+        {
+            var maybe = new Maybe<T>(value);
+            Predicate<T> predicate = _ => true;
+
+            var result = maybe.Filter(predicate);
+
+            result.Should().Equal(maybe);
+        }
+
+        [Theory]
+        [InlineData("Test")]
+        [InlineData(10)]
+        [InlineData(typeof(object))]
+        public void WhenSome_PredicateFalse_ReturnsNone<T>(T value)
+        {
+            var maybe = new Maybe<T>(value);
+            Predicate<T> predicate = _ => false;
+
+            var result = maybe.Filter(predicate);
+
+            result.Should().BeEmpty();
+        }
+
+
+        [Fact]
+        public async Task WhenNone_AsyncPredicateNotInvoked()
+        {
+            var maybe = default(Maybe<object>);
+            int calls = 0;
+            Func<object, Task<bool>> predicate = _ =>
+            {
+                calls++;
+                return Task.FromResult(true);
+            };
+
+            var result = await maybe.Filter(predicate);
+
+            result.Should().BeEmpty();
+            calls.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("Test")]
+        [InlineData(10)]
+        [InlineData(typeof(object))]
+        public async Task WhenSome_AsyncPredicateTrue_ReturnsSome<T>(T value)
+        {
+            var maybe = new Maybe<T>(value);
+            Func<T, Task<bool>> predicate = _ => Task.FromResult(true);
+
+            var result = await maybe.Filter(predicate);
+
+            result.Should().Equal(maybe);
+        }
+
+        [Theory]
+        [InlineData("Test")]
+        [InlineData(10)]
+        [InlineData(typeof(object))]
+        public async Task WhenSome_AsyncPredicateFalse_ReturnsNone<T>(T value)
+        {
+            var maybe = new Maybe<T>(value);
+            Func<T, Task<bool>> predicate = _ => Task.FromResult(false);
+
+            var result = await maybe.Filter(predicate);
+
+            result.Should().BeEmpty();
+        }
+    }
+}

--- a/src/SharpJuice.Essentials/Maybe.cs
+++ b/src/SharpJuice.Essentials/Maybe.cs
@@ -60,6 +60,20 @@ namespace SharpJuice.Essentials
                 : new Maybe<TResult>();
         }
 
+        public Maybe<T> Filter(Predicate<T> predicate)
+        {
+            return _hasValue && predicate(_value)
+                ? this
+                : default;
+        }
+
+        public async Task<Maybe<T>> Filter(Func<T, Task<bool>> predicate)
+        {
+            return _hasValue && await predicate(_value)
+                ? this
+                : default;
+        }
+
         public T OrElse(Func<T> func) => _hasValue ? _value : func();
 
         public Task<T> OrElse(Func<Task<T>> func)

--- a/src/SharpJuice.Essentials/TaskExtensions.cs
+++ b/src/SharpJuice.Essentials/TaskExtensions.cs
@@ -29,6 +29,20 @@ namespace SharpJuice.Essentials
             return await (await task).Bind(binder);
         }
 
+        public static async Task<Maybe<T>> Filter<T>(
+            this Task<Maybe<T>> task,
+            Predicate<T> predicate)
+        {
+            return (await task).Filter(predicate);
+        }
+
+        public static async Task<Maybe<T>> Filter<T>(
+            this Task<Maybe<T>> task,
+            Func<T, Task<bool>> predicate)
+        {
+            return await (await task).Filter(predicate);
+        }
+
         public static async Task<T> OrElse<T>(this Task<Maybe<T>> task, Func<T> func)
         {
             return (await task).OrElse(func);


### PR DESCRIPTION
This changeset introduces filter by predicate method, instead of relying on clunky Linq.Where.